### PR TITLE
Handle decoder flush in streaming pump

### DIFF
--- a/packages/chatkit-react-native/src/networking/streaming.ts
+++ b/packages/chatkit-react-native/src/networking/streaming.ts
@@ -1,0 +1,31 @@
+export interface StreamingHooks {
+  onChunk: (chunk: string) => void | Promise<void>;
+  onResponseEnd: () => void | Promise<void>;
+}
+
+export async function pump(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  decoder: TextDecoder,
+  hooks: StreamingHooks,
+): Promise<void> {
+  while (true) {
+    const { value, done } = await reader.read();
+
+    if (done) {
+      const flushed = decoder.decode();
+      if (flushed.length > 0) {
+        await hooks.onChunk(flushed);
+      }
+      await hooks.onResponseEnd();
+      reader.releaseLock?.();
+      break;
+    }
+
+    if (value) {
+      const chunk = decoder.decode(value, { stream: true });
+      if (chunk.length > 0) {
+        await hooks.onChunk(chunk);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a streaming pump helper that flushes the text decoder and forwards the final chunk before ending the response
- release the stream reader lock after completion so future consumers can reuse the stream

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68e45b0aec348326b027637b9c754a4d